### PR TITLE
fix shellcheck CI configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,27 +52,3 @@ jobs:
         with:
           version: ${{ steps.golangci_version.version }}
           working-directory: server
-
-  lint-sh:
-    permissions:
-      security-events: write
-
-    name: 
-      - name: Checkout Git Repository
-        uses: actions/checkout@v4
-        with:
-          # we need a full history for differential shellcheck
-          fetch-depth: 0
-
-      - name: Differential ShellCheck
-        id: ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - if: ${{ always() }}
-        name: Upload ShellCheck defects
-        uses: actions/upload-artifact@v4
-        with:
-          name: Differential ShellCheck SARIF
-          path: ${{ steps.ShellCheck.outputs.sarif }}

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -61,3 +61,29 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
+
+  lint-sh:
+    name: Lint shell scripts
+    runs-on: ubuntu-22.04
+    permissions:
+      security-events: write
+
+    steps: 
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+        with:
+          # we need a full history for differential shellcheck
+          fetch-depth: 0
+
+      - name: Differential ShellCheck
+        id: ShellCheck
+        uses: redhat-plumbers-in-action/differential-shellcheck@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - if: ${{ always() }}
+        name: Upload ShellCheck defects
+        uses: actions/upload-artifact@v4
+        with:
+          name: Differential ShellCheck SARIF
+          path: ${{ steps.ShellCheck.outputs.sarif }}


### PR DESCRIPTION
We should run this as a part of security checks, not as a part of CI for `server/` changes.