### PR TITLE
Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,17 @@ updates:
     interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: gomod
-  directory: "/server"
+  directory: "/e2e"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: gomod
   directory: "/operator"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  directory: "/server"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
@@ -22,6 +27,11 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: gomod
   directory: "/hack/kustomize"
+  schedule:
+    interval: weekly
+  open-pull-requests-limit: 10
+- package-ecosystem: gomod
+  directory: "/hack/mockgen"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,16 +7,28 @@ updates:
   open-pull-requests-limit: 10
 - package-ecosystem: gomod
   directory: "/e2e"
+  groups:
+    kubernetes:
+      patterns:
+      - "k8s.io/*"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: gomod
   directory: "/operator"
+  groups:
+    kubernetes:
+      patterns:
+      - "k8s.io/*"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10
 - package-ecosystem: gomod
   directory: "/server"
+  groups:
+    kubernetes:
+      patterns:
+      - "k8s.io/*"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
This includes two changes to our dependabot configuration:

- Dependabot now watches both the `e2e/` and `hack/mockgen/` directories.  They should now see updates alongside all the other tools.
- Dependabot will group all `k8s.io/*` dependencies into one pull request for each `go.mod` that requests it.  This means when we get updates to `k8s.io/api`, `k8s.io/apimachinery`, and `k8s.io/client-go`, we'll only see 3 pull requests (one each to `e2e/`, `operator/`, and `server/`), not 9 pull requests.