### PR TITLE
cd: build/push images

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         include:
           - directory: server
-            image_base: quay.io/konflux-workspaces/workspace-server
+            image_base: quay.io/konflux-workspaces/workspaces-server
           - directory: operator
-            image_base: quay.io/konflux-workspaces/workspace-operator
+            image_base: quay.io/konflux-workspaces/workspaces-operator
 
     steps:
       - name: Checkout Git Repository

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,14 +35,11 @@ jobs:
 
       - name: Determine image tag
         id: tag
-        env:
-          PR_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" -eq "pull_request_target" ]]; then
-            echo "tag=${{ matrix.image_base }}:pr-${PR_NUMBER}-${PR_SHA:0:8}" >> ${GITHUB_OUTPUT}
+            echo "tag=${{ matrix.image_base }}:pr-${{ github.event.pull_request.number }}-${GITHUB_SHA:0:8}" >> ${GITHUB_OUTPUT}
           else
-            echo "tag=${{ matrix.image_base }}:${PR_SHA:0:8}" >> ${GITHUB_OUTPUT}
+            echo "tag=${{ matrix.image_base }}:${GITHUB_SHA:0:8}" >> ${GITHUB_OUTPUT}
           fi
 
       - name: Build image
@@ -55,8 +52,6 @@ jobs:
             docker tag "${IMG}" "${LATEST}"
           fi
 
-      # we use quay for release artifacts (on push events) and ghcr.io for
-        # testing (on pull_request_target events)
       - name: Login to Quay
         uses: docker/login-action@v3
         with:
@@ -66,4 +61,4 @@ jobs:
 
       - name: Push images
         run: |
-          docker push -a ${{ steps.tag.outputs.tag }}
+          docker push -a ${{ matrix.image_base }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -1,0 +1,66 @@
+name: Build container images
+
+on: # yamllint disable-line rule:truthy
+  push:
+    branches: [main]
+  pull_request_target:
+    types: [opened, syncronize, reopened, ready_for_review]
+
+jobs:
+  build:
+    name: Build images
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - directory: server
+            image_base: quay.io/konflux-workspaces/workspace-server
+          - directory: operator
+            image_base: quay.io/konflux-workspaces/workspace-operator
+
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'pull_request_target' }}
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+        if: ${{ github.event_name == 'push' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine image tag
+        id: tag
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" -eq "pull_request_target" ]]; then
+            echo "tag=${{ matrix.image_base }}:pr-${{ github.event.pull_request.number }}-$(git describe --always)" >> ${GITHUB_OUTPUT}
+          else
+            echo "tag=${{ matrix.image_base }}:$(git describe --always)" >> ${GITHUB_OUTPUT}
+          fi
+
+      - name: Build image
+        env:
+          LATEST: ${{ matrix.image_base }}:latest
+          IMG: ${{ steps.tag.outputs.tag }}
+        run: |
+          make -C "${{ matrix.directory }}" docker-build
+          if [[ "${GITHUB_EVENT_NAME}" -eq "push" ]]; then
+            docker tag "${IMG}" "${LATEST}"
+          fi
+
+      # we use quay for release artifacts (on push events) and ghcr.io for
+        # testing (on pull_request_target events)
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Push images
+        run: |
+          docker push -a ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -35,11 +35,14 @@ jobs:
 
       - name: Determine image tag
         id: tag
+        env:
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           if [[ "${GITHUB_EVENT_NAME}" -eq "pull_request_target" ]]; then
-            echo "tag=${{ matrix.image_base }}:pr-${{ github.event.pull_request.number }}-$(git describe --always)" >> ${GITHUB_OUTPUT}
+            echo "tag=${{ matrix.image_base }}:pr-${PR_NUMBER}-${PR_SHA:0:8}" >> ${GITHUB_OUTPUT}
           else
-            echo "tag=${{ matrix.image_base }}:$(git describe --always)" >> ${GITHUB_OUTPUT}
+            echo "tag=${{ matrix.image_base }}:${PR_SHA:0:8}" >> ${GITHUB_OUTPUT}
           fi
 
       - name: Build image


### PR DESCRIPTION
Push built artifacts to quay.io for further distribution, either for testing or use in production.

Containers are tagged under the following naming convention:

- Release artifacts are tagged with the first 8 characters of the latest commit.  The most-recently-pushed container will also be tagged with `latest`.
- Testing artifacts are tagged as `pr-${PR_NUMBER}-${COMMIT}`, where $PR_NUMBER is the pull request number, and $COMMIT is the first 8 characters on the latest commit.  This naming convention distinguishes testing artifacts from release artifacts.