### PR TITLE
ci: move away from differential shellcheck

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -71,19 +71,23 @@ jobs:
     steps: 
       - name: Checkout Git Repository
         uses: actions/checkout@v4
-        with:
-          # we need a full history for differential shellcheck
-          fetch-depth: 0
 
-      - name: Differential ShellCheck
-        id: ShellCheck
-        uses: redhat-plumbers-in-action/differential-shellcheck@v5
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: cargo install shellcheck-sarif sarif-fmt
+
+      - name: Lint shell scripts
+        run: |
+          find . -executable -type f -regex ".*hack.*" -print0 | \
+            xargs -0 shellcheck -s bash -o all -f json | \
+            shellcheck-sarif > results.sarif
+          sarif-fmt -c always < results.sarif
+
+          if [[ $(jq '.runs[].results | length' results.sarif) -ne "0" ]]; then
+            exit 1
+          fi
 
       - if: ${{ always() }}
         name: Upload ShellCheck defects
         uses: actions/upload-artifact@v4
         with:
-          name: Differential ShellCheck SARIF
-          path: ${{ steps.ShellCheck.outputs.sarif }}
+          name: ShellCheck SARIF
+          path: results.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# produced as a part of CI
+results.sarif

--- a/hack/demo.sh
+++ b/hack/demo.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
-set -e 
+set -e -o pipefail
 
 export QUAY_NAMESPACE=${QUAY_NAMESPACE:-workspaces}
 
-SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+CURRENT_DIR="$(readlink -f "$0")"
+SCRIPT_DIR="$(dirname "${CURRENT_DIR}")"
 
-( "$SCRIPT_DIR/install_toolchain.sh" )
-( "$SCRIPT_DIR/install_workspaces.sh" && make -C e2e test )
+( "${SCRIPT_DIR}/install_toolchain.sh" )
+( "${SCRIPT_DIR}/install_workspaces.sh" && make -C e2e test )

--- a/hack/install_toolchain.sh
+++ b/hack/install_toolchain.sh
@@ -6,7 +6,7 @@ export QUAY_NAMESPACE=${QUAY_NAMESPACE:-workspaces}
 
 f=$(mktemp --directory /tmp/toolchain.XXXX)
 
-cd "$f"
+cd "${f}"
 
 git clone --depth 2 https://github.com/codeready-toolchain/member-operator.git
 git clone --depth 2 --branch public-viewer https://github.com/filariow/toolchain-e2e.git

--- a/hack/install_workspaces.sh
+++ b/hack/install_workspaces.sh
@@ -6,7 +6,7 @@ export QUAY_NAMESPACE=${QUAY_NAMESPACE:-workspaces}
 
 f=$(mktemp --directory /tmp/workspaces-demo.XXXX)
 
-cp -r hack/ operator/ e2e/ server/ "$f"
-cd "$f" 
+cp -r hack/ operator/ e2e/ server/ "${f}"
+cd "${f}"
 
 make -C e2e prepare

--- a/server/hack/deploy.sh
+++ b/server/hack/deploy.sh
@@ -26,7 +26,7 @@ cp -r "${ROOT_DIR}/server/manifests" "${f}/manifests"
 cd "${f}/manifests/default"
 
 # updating JWT configuration
-if [ -n "${JWKS_URL}" ]; then 
+if [[ -n "${JWKS_URL}" ]]; then
   ${YQ} eval \
     '.authSources.jwtSource.jwt.jwksUrl = "'"${JWKS_URL}"'"' \
     --inplace "${f}/manifests/server/proxy-config/traefik.yaml"
@@ -37,8 +37,8 @@ else
 
   ${KUSTOMIZE} edit add secret traefik-jwt-keys \
     --disableNameSuffixHash \
-    --from-literal=public="$public_key" \
-    --from-literal=private="$private_key"
+    --from-literal=public="${public_key}" \
+    --from-literal=private="${private_key}"
 
   # update traefik config
   ${YQ} eval \


### PR DESCRIPTION
Differential shellcheck was ignoring errors in some cases, which was causing shellcheck warnings not to be picked up.  Move away from it and use [shellcheck-sarif][1] as a SARIF provider.

[1]: https://docs.rs/crate/shellcheck-sarif/latest