### PR TITLE
Build kubesaw components as a part of ci

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -9,6 +9,10 @@ on: # yamllint disable-line rule:truthy
 env:
   GO_VERSION: 1.22
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build-workspaces:
     name: Build workspace images

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -10,8 +10,8 @@ env:
   GO_VERSION: 1.22
 
 jobs:
-  build:
-    name: Build images
+  build-workspaces:
+    name: Build workspace images
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -69,3 +69,32 @@ jobs:
 
       - name: Push images
         run: docker push -a ${{ matrix.image_base }}
+
+  build-kubesaw:
+    name: Build kubesaw components
+    runs-on: ubuntu-22.04
+    if: ${{ github.event_name == 'pull_request_target' }}
+    steps:
+      - name: Checkout Git Repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Build and push images
+        run: |
+          export TAG=pr-${{ github.event.pull_request.number }}-${GITHUB_SHA:0:8}
+          IMAGE_BUILDER=docker hack/toolchain_build_push.sh "${TAG}"

--- a/hack/toolchain_install.sh
+++ b/hack/toolchain_install.sh
@@ -4,7 +4,7 @@ set -e
 
 # parse input
 BRANCH=${BRANCH:-pubviewer-mvp}
-export QUAY_NAMESPACE=${QUAY_NAMESPACE:-workspaces}
+export QUAY_NAMESPACE=${QUAY_NAMESPACE:-konflux-workspaces}
 TAG=${1:-e2etest}
 KUBECLI=${KUBECLI:-kubectl}
 


### PR DESCRIPTION
We don't need them during release builds (i.e. a push to main), but they are needed as a part of ci.