### PR TITLE
use commit sha from PR head

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -50,7 +50,8 @@ jobs:
         id: tag
         run: |
           if [[ "${GITHUB_EVENT_NAME}" = "pull_request_target" ]]; then
-            export IMG="${{ matrix.image_base }}:pr-${{ github.event.pull_request.number }}-${GITHUB_SHA:0:8}"
+            export PR_SHA=${{ github.event.pull_request.head.sha }}
+            export IMG="${{ matrix.image_base }}:pr-${{ github.event.pull_request.number }}-${PR_SHA:0:8}"
           else
             export IMG="${{ matrix.image_base }}:${GITHUB_SHA:0:8}"
           fi
@@ -108,6 +109,8 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
       - name: Build and push images for ${{ matrix.scope }}
+        env:
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          export TAG=pr-${{ github.event.pull_request.number }}-${GITHUB_SHA:0:8}
+          export TAG=pr-${{ github.event.pull_request.number }}-${PR_SHA:0:8}
           IMAGE_BUILDER=docker hack/toolchain_build_push_${{ matrix.scope }}.sh "${TAG}"


### PR DESCRIPTION
In pull_request_target events, `$GITHUB_SHA` points to the base commit on `main`, not the latest commit on the PR branch.  Fix this.