### PR TITLE
use correct branch in deployment

### DIFF
--- a/ci/toolchain_manager.sh
+++ b/ci/toolchain_manager.sh
@@ -41,7 +41,7 @@ function publish {
 }
 
 function deploy {
-    clone "${TOOLCHAIN_E2E_REPO}" "${BRANCH}"
+    clone "${TOOLCHAIN_E2E_REPO}" "${TOOLCHAIN_E2E_BRANCH}"
 
     make -C toolchain-e2e deploy-published-operators-e2e \
         FORCED_TAG="${TAG}" \


### PR DESCRIPTION
See [here][1] for context.

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/50802/rehearse-50802-pull-ci-konflux-workspaces-workspaces-main-e2e/1786059626001731584