### PR TITLE
run server CI when dependencies change

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,8 @@ on: # yamllint disable-line rule:truthy
   pull_request:
     paths:
       - "server/**"
+      - "hack/tools/**"
+      - ".github/**"
   push:
     branches: [main]
 


### PR DESCRIPTION
Currently, the server/ CI workflow only runs if a PR has changes in the server/ directory.  This misses running some tools like linting when they get updated (for instance, see [PR #107][1]).  Run them when changes affect hack/tools/** and .github/** as well.

[1]: https://github.com/konflux-workspaces/workspaces/pull/107/checks?sha=5ef9206bc7d5bb502d8f095602fc15035fbb3a65