### PR TITLE
e2e: check parse results of RSA private key

### DIFF
--- a/e2e/pkg/auth/auth.go
+++ b/e2e/pkg/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
 
 	"github.com/golang-jwt/jwt/v5"
 	corev1 "k8s.io/api/core/v1"
@@ -24,8 +25,14 @@ func BuildJwtForUser(ctx context.Context, user string) (string, error) {
 	}
 
 	block, _ := pem.Decode(s.Data["private"])
-	parseResult, _ := x509.ParsePKCS8PrivateKey(block.Bytes)
-	key := parseResult.(*rsa.PrivateKey)
+	parseResult, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return "", err
+	}
+	key, ok := parseResult.(*rsa.PrivateKey)
+	if !ok {
+		return "", fmt.Errorf("Failed to retrieve RSA private key")
+	}
 
 	return jwt.NewWithClaims(jwt.SigningMethodRS512,
 		jwt.MapClaims{

--- a/e2e/pkg/auth/auth.go
+++ b/e2e/pkg/auth/auth.go
@@ -31,7 +31,7 @@ func BuildJwtForUser(ctx context.Context, user string) (string, error) {
 	}
 	key, ok := parseResult.(*rsa.PrivateKey)
 	if !ok {
-		return "", fmt.Errorf("Failed to retrieve RSA private key")
+		return "", fmt.Errorf("failed to retrieve RSA private key")
 	}
 
 	return jwt.NewWithClaims(jwt.SigningMethodRS512,


### PR DESCRIPTION
We have two error cases here:

 - The decoded data is not valid.
 - The x509 certificate doesn't contain an RSA private key (for instance, it could be an ECDSA or an ed25519 key).

Handle both of these cases and report the error, rather than panic when we eventually run into an issue.