### PR TITLE
enable logging in controller-runtime

### DIFF
--- a/server/main.go
+++ b/server/main.go
@@ -7,10 +7,12 @@ import (
 	"os"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/konflux-workspaces/workspaces/server/core/workspace"
 	"github.com/konflux-workspaces/workspaces/server/persistence/kube"
 	"github.com/konflux-workspaces/workspaces/server/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 const DefaultAddr string = ":8080"
@@ -26,6 +28,7 @@ func main() {
 
 func run() error {
 	l := slog.Default()
+	log.SetLogger(logr.FromSlogHandler(l.Handler()))
 
 	// fetch configuration
 	wns, ok := os.LookupEnv("WORKSPACES_NAMESPACE")


### PR DESCRIPTION
controller-runtime expects a logger to be setup using the `logr` package and registered using the `log.SetLogger` method.  Without this, controller-runtime refuses to propogate logging and causes issues.