### PR TITLE
allow setting alternative image builders

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -9,6 +9,8 @@ QUAY_NAMESPACE ?= workspaces
 OPERATOR_IMG ?= quay.io/$(QUAY_NAMESPACE)/workspaces-op:test-${DATE_SUFFIX}
 SERVER_IMG ?= quay.io/$(QUAY_NAMESPACE)/workspaces-rest:test-${DATE_SUFFIX}
 CONCURRENCY ?= 1
+IMAGE_BUILDER ?= docker
+export IMAGE_BUILDER
 
 .PHONY: vet
 vet:
@@ -16,13 +18,13 @@ vet:
 
 .PHONY: build-images
 build-images:
-	IMG=$(OPERATOR_IMG) make -C ../operator/ docker-build
-	IMG=$(SERVER_IMG) make -C ../server/ docker-build
+	IMG=$(OPERATOR_IMG) $(MAKE) -C ../operator/ docker-build
+	IMG=$(SERVER_IMG) $(MAKE) -C ../server/ docker-build
 
 .PHONY: push-images
 push-images:
-	docker push $(OPERATOR_IMG) 
-	docker push $(SERVER_IMG)
+	$(IMAGE_BUILDER) push $(OPERATOR_IMG)
+	$(IMAGE_BUILDER) push $(SERVER_IMG)
 
 .PHONY: deploy-operator
 deploy-operator:

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -55,6 +55,10 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.26.0
 
+# Set the default container runtime to docker, since most users will have this installed.  For those
+# that don't, this lets them override it and still use their tool of choice.
+IMAGE_BUILDER ?= docker
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -128,11 +132,11 @@ run: manifests generate fmt vet ## Run a controller from your host.
 # More info: https://docs.docker.com/develop/develop-images/build_enhancements/
 .PHONY: docker-build
 docker-build: test ## Build docker image with the manager.
-	docker build -t ${IMG} .
+	$(IMAGE_BUILDER) build -t ${IMG} .
 
 .PHONY: docker-push
 docker-push: ## Push docker image with the manager.
-	docker push ${IMG}
+	$(IMAGE_BUILDER) push ${IMG}
 
 # PLATFORMS defines the target platforms for  the manager image be build to provide support to multiple
 # architectures. (i.e. make docker-buildx IMG=myregistry/mypoperator:0.0.1). To use this option you need to:
@@ -237,7 +241,7 @@ bundle: manifests kustomize operator-sdk ## Generate bundle manifests and metada
 
 .PHONY: bundle-build
 bundle-build: ## Build the bundle image.
-	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+	$(IMAGE_BUILDER) build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 .PHONY: bundle-push
 bundle-push: ## Push the bundle image.
@@ -277,7 +281,7 @@ endif
 # https://github.com/operator-framework/community-operators/blob/7f1438c/docs/packaging-operator.md#updating-your-existing-operator
 .PHONY: catalog-build
 catalog-build: opm ## Build a catalog image.
-	$(OPM) index add --container-tool docker --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
+	$(OPM) index add --container-tool $(IMAGE_BUILDER) --mode semver --tag $(CATALOG_IMG) --bundles $(BUNDLE_IMGS) $(FROM_INDEX_OPT)
 
 # Push the catalog image.
 .PHONY: catalog-push

--- a/server/Makefile
+++ b/server/Makefile
@@ -6,6 +6,8 @@ $(LOCALBIN):
 GO ?= go
 LD_FLAGS ?= -s -w
 
+IMAGE_BUILDER ?= docker
+
 IMG ?= workspaces/rest-api:latest
 NAMESPACE ?= workspaces-system
 
@@ -119,7 +121,7 @@ test-with-coverage: generate-code
 
 .PHONY: docker-build
 docker-build:
-	docker build -t ${IMG} -f Dockerfile ..
+	$(IMAGE_BUILDER) build -t ${IMG} -f Dockerfile ..
 
 .PHONY: deploy
 deploy: kustomize yq


### PR DESCRIPTION
This allows the build system to use alternative container runtimes for building containers, such as podman.  Behavior can be set using the `IMAGE_BUILDER` parameter/env var.