### PR TITLE
e2e: use client-go's kubeconfig loaders

### DIFF
--- a/e2e/hook/host_client.go
+++ b/e2e/hook/host_client.go
@@ -38,7 +38,7 @@ func injectHostClient(ctx context.Context, sc *godog.Scenario) (context.Context,
 
 	c, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
-		return nil, fmt.Errorf("error building config: %v", err)
+		return nil, fmt.Errorf("error building client: %v", err)
 	}
 
 	tc := cli.New(c, sc.Id)


### PR DESCRIPTION
client-go does the right thing in more circumstances than we do.  On clusters, it should pick up credentials according to the secrets projected into the pod, while on desktop clients, it should respect `KUBECONFIG` env vars (defaulting to `~/.kube/config`).

This is a copy of what toolchain-e2e does during test initialization. See [init.go] and [kube_client.go] for more details.

[init.go]: https://github.com/codeready-toolchain/toolchain-e2e/blob/master/testsupport/init.go#L65-L74
[kube_client.go]: https://github.com/codeready-toolchain/toolchain-e2e/blob/master/testsupport/util/kube_client.go#L13-L20