### PR TITLE
ci: run more tests more often

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,7 @@
 name: Server CI
 
 on: # yamllint disable-line rule:truthy
-  pull_request:
-    paths:
-      - "server/**"
-      - "hack/tools/**"
-      - ".github/**"
+  pull_request: {}
   push:
     branches: [main]
 
@@ -17,6 +13,11 @@ jobs:
   unit:
     name: Unit tests
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        include:
+          - directory: server
+          - directory: operator
 
     steps:
       - name: Set up Go
@@ -29,7 +30,7 @@ jobs:
 
       - name: Run tests
         # todo: set up code coverage?
-        run: make -C server test
+        run: make -C "${{ matrix.directory }}" test
 
   lint-go:
     name: Lint code
@@ -47,7 +48,7 @@ jobs:
       - name: Determine golang-ci version
         id: golangci_version
         run: |
-          echo "version=$(go mod edit -json | jq '.Require | map(select(.Path == "github.com/golangci/golangci-lint"))[].Version')" >> $GITHUB_OUTPUT
+          echo "version=$(go mod edit -json hack/tools/golang-ci/go.mod | jq '.Require | map(select(.Path == "github.com/golangci/golangci-lint"))[].Version')" >> $GITHUB_OUTPUT
 
       - name: Lint with golang-ci
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
If we want to make the unit-testing job always pass before we can merge a PR, we need to have it run in almost all circumstances. With this change, all PRs will have unit tests run, not just when relevant paths have changed.

This also sets up unit testing for operator/ and fixes a bug where we were running the latest version of golang-ci instead of the pinned version.