### PR TITLE
e2e: add internal workspaces schema to workspaces client

### DIFF
--- a/e2e/pkg/rest/client.go
+++ b/e2e/pkg/rest/client.go
@@ -62,6 +62,7 @@ func BuildWorkspacesClient(ctx context.Context) (client.Client, error) {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 	utilruntime.Must(restworkspacesv1alpha1.AddToScheme(scheme))
 	utilruntime.Must(toolchainv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(workspacesiov1alpha1.AddToScheme(scheme))
 
 	u := tcontext.RetrieveUser(ctx)
 	k := tcontext.RetrieveUnauthKubeconfig(ctx)


### PR DESCRIPTION
This was causing test failures, since the workspace client wasn't informed of how to deal with internal workspaces.  This should be safe to revert once #126 is merged.