### PR TITLE
Use https for workspace clients

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -60,7 +60,7 @@ env:
 
 .PHONY: test
 test: vet clean
-	PROXY_URL="$${PROXY_URL:-$$($(KUBECLI) get route workspaces-rest-api-server -n workspaces-system -o jsonpath='{.status.ingress[0].host}')}" \
+	PROXY_URL="$${PROXY_URL:-https://$$($(KUBECLI) get route workspaces-rest-api-server -n workspaces-system -o jsonpath='{.status.ingress[0].host}')}" \
 		KUBESPACE_NAMESPACE=$$($(KUBECLI) get namespaces -o name | grep toolchain-host | cut -d'/' -f2) \
 		WORKSPACES_NAMESPACE="workspaces-system" \
 		E2E_USE_INSECURE_TLS="$(USE_INSECURE_TLS)" \
@@ -68,7 +68,7 @@ test: vet clean
 
 .PHONY: wip
 wip: vet clean
-	PROXY_URL="$${PROXY_URL:-$$($(KUBECLI) get route workspaces-rest-api-server -n workspaces-system -o jsonpath='{.status.ingress[0].host}')}" \
+	PROXY_URL="$${PROXY_URL:-https://$$($(KUBECLI) get route workspaces-rest-api-server -n workspaces-system -o jsonpath='{.status.ingress[0].host}')}" \
 		KUBESPACE_NAMESPACE=$$($(KUBECLI) get namespaces -o name | grep toolchain-host | cut -d'/' -f2) \
 		WORKSPACES_NAMESPACE="workspaces-system" \
 		E2E_USE_INSECURE_TLS="$(USE_INSECURE_TLS)" \

--- a/server/config/network/route.yaml
+++ b/server/config/network/route.yaml
@@ -10,6 +10,8 @@ spec:
   host: ''
   port:
     targetPort: 8000
+  tls:
+    termination: edge
   to:
     kind: Service
     name: workspaces-rest-api-server


### PR DESCRIPTION
This fixes two related issues:
- The route wasn't terminating TLS connections properly, so any https connection to the rest api would fail.
- `PROXY_URL` wasn't setting a protocol, which was causing our client to default to http connections.

With these changes, the rest-api server should be properly setup to handle incoming https connections.

I believe this is what was causing openshift-ci tests to fail, though I'm not 100% certain.  I was able to reproduce similar behavior to the failures I was seeing over there by applying only the second commit (525dcc2).