### PR TITLE
e2e: fix ctx return in workspace_when

### DIFF
--- a/e2e/step/workspace/workspace_when.go
+++ b/e2e/step/workspace/workspace_when.go
@@ -73,7 +73,7 @@ func ownerChangesVisibilityTo(ctx context.Context, visibility workspacesv1alpha1
 		return nil
 	})
 	if err != nil {
-		return nil, err
+		return ctx, err
 	}
 
 	return tcontext.InjectInternalWorkspace(ctx, w), nil


### PR DESCRIPTION
Hooks relies on the context to be returned here.
Returning `nil` here breaks After hooks.

Signed-off-by: Francesco Ilario <filario@redhat.com>
