### PR TITLE
fix typo in actions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -155,7 +155,7 @@ jobs:
         uses: ncipollo/release-action@v1
         with:
           artifacts: "operator/out/operator.tar.gz,server/out/server.tar.gz"
-          tag: ${{ input.version }}
+          tag: ${{ inputs.version }}
           commit: main
           draft: true
           generateReleaseNotes: true


### PR DESCRIPTION
I wish github had a way of linting our workflow definitions so we didn't have to play golf with them, but until then, this is what we have to do.