### PR TITLE
release: use OUTDIR for tarball manifest paths

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -292,7 +292,7 @@ catalog-build: opm ## Build a catalog image.
 catalog-push: ## Push a catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
 
-MANIFEST_TARBALL := $(realpath out/operator.tar.gz)
+MANIFEST_TARBALL := $(realpath $(OUTDIR)/operator.tar.gz)
 
 # Package the config/ directory into a tarball for deployment via infra-deployments.
 .PHONY: package

--- a/server/Makefile
+++ b/server/Makefile
@@ -3,7 +3,7 @@ LOCALBIN := $(ROOT_DIR)/bin
 $(LOCALBIN):
 	mkdir $(LOCALBIN)
 
-OUTDIR := $(ROOT_DIR)/out/
+OUTDIR := $(ROOT_DIR)/out
 $(OUTDIR):
 	@mkdir $(OUTDIR)
 
@@ -25,7 +25,7 @@ YQ ?= $(LOCALBIN)/yq
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 GOLANG_CI ?= $(GO) run -modfile $(shell dirname $(ROOT_DIR))/hack/tools/golang-ci/go.mod github.com/golangci/golangci-lint/cmd/golangci-lint
 
-MANIFEST_TARBALL := $(ROOT_DIR)/server/out/server.tar.gz
+MANIFEST_TARBALL := $(OUTDIR)/server.tar.gz
 JWKS_URL := https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/certs
 
 ##@ General


### PR DESCRIPTION
Context: https://github.com/konflux-workspaces/workspaces/actions/runs/9553798236/job/26333553977