### PR TITLE
e2e: set container tool env vars explicitly

### DIFF
--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -10,7 +10,6 @@ OPERATOR_IMG ?= quay.io/$(QUAY_NAMESPACE)/workspaces-op:test-${DATE_SUFFIX}
 SERVER_IMG ?= quay.io/$(QUAY_NAMESPACE)/workspaces-rest:test-${DATE_SUFFIX}
 CONCURRENCY ?= 1
 IMAGE_BUILDER ?= docker
-export IMAGE_BUILDER
 
 USE_INSECURE_TLS ?= false
 
@@ -20,8 +19,8 @@ vet:
 
 .PHONY: build-images
 build-images:
-	IMG=$(OPERATOR_IMG) $(MAKE) -C ../operator/ docker-build
-	IMG=$(SERVER_IMG) $(MAKE) -C ../server/ docker-build
+	CONTAINER_TOOL=$(IMAGE_BUILDER) IMG=$(OPERATOR_IMG) $(MAKE) -C ../operator/ docker-build
+	IMAGE_BUILDER=$(IMAGE_BUILDER) IMG=$(SERVER_IMG) $(MAKE) -C ../server/ docker-build
 
 .PHONY: push-images
 push-images:


### PR DESCRIPTION
Since 000d58a (PR #174), operator/ hasn't respected the `IMAGE_BUILDER` env var, instead using `CONTAINER_TOOL`.  This means users trying to build with alternative image builders need to set two environment variables, not one.  This impacts e2e builds of images, where the assumption was that the `IMAGE_BUILDER` environment variable would control both operator and server.

To remedy this, have e2e infrastructure set `CONTAINER_TOOL` and `IMAGE_BUILDER` explicitly when invoking builds of each component.