### PR TITLE
add CRD validation for visibility

### DIFF
--- a/operator/api/v1alpha1/internalworkspace_types.go
+++ b/operator/api/v1alpha1/internalworkspace_types.go
@@ -66,6 +66,7 @@ type InternalWorkspaceSpec struct {
 	//+required
 	DisplayName string `json:"displayName"`
 	//+required
+	//+kubebuilder:validation:Enum:=community;private
 	Visibility InternalWorkspaceVisibility `json:"visibility"`
 	//+required
 	Owner UserInfo `json:"owner"`

--- a/operator/config/crd/bases/workspaces.konflux.io_internalworkspaces.yaml
+++ b/operator/config/crd/bases/workspaces.konflux.io_internalworkspaces.yaml
@@ -67,6 +67,9 @@ spec:
                 - jwtInfo
                 type: object
               visibility:
+                enum:
+                - community
+                - private
                 type: string
             required:
             - displayName

--- a/server/api/v1alpha1/workspace_types.go
+++ b/server/api/v1alpha1/workspace_types.go
@@ -32,6 +32,7 @@ const (
 // WorkspaceSpec defines the desired state of Workspace
 type WorkspaceSpec struct {
 	//+required
+	//+kubebuilder:validation:Enum:=community;private
 	Visibility WorkspaceVisibility `json:"visibility"`
 }
 

--- a/server/config/crd/bases/workspaces.konflux.io_workspaces.yaml
+++ b/server/config/crd/bases/workspaces.konflux.io_workspaces.yaml
@@ -44,6 +44,9 @@ spec:
             description: WorkspaceSpec defines the desired state of Workspace
             properties:
               visibility:
+                enum:
+                - community
+                - private
                 type: string
             required:
             - visibility


### PR DESCRIPTION
Visibility field is only allowed to have value `community` or `private`.
This change enforces manifest validation on the visibility field for both InternalWorkspace and Workspace.

Signed-off-by: Francesco Ilario <filario@redhat.com>
