### PR TITLE
makefiles default to help, enriched help output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,28 @@ BOOK_PATH = $(PWD)/doc/book
 MDBOOK_VERSION ?= v0.4.40
 VALE_VERSION := v3.6.0
 
+##@ General
+
+# The help target prints out all targets with their descriptions organized
+# beneath their categories. The categories are represented by '##@' and the
+# target descriptions by '##'. The awk commands is responsible for reading the
+# entire set of makefiles included in this invocation, looking for lines of the
+# file as xyz: ## something, and then pretty-format the target and help. Then,
+# if there's a line with ##@ something, that gets pretty-printed as a category.
+# More info on the usage of ANSI control characters for terminal formatting:
+# https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_parameters
+# More info on the awk command:
+# http://linuxcommand.org/lc3_adv_awk.php
+
+.PHONY: help
+help: ## Display this help.
+	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
+##@ Book
+
 .PHONY: book
-book:
+book: ## Build the book.
 	$(CONTAINER_TOOL) run --rm \
 		--workdir "/book" \
 		--name "workspaces-mdbook" \
@@ -21,21 +41,23 @@ book:
 		build
 
 .PHONY: lint-book-sync
-lint-book-sync:
+lint-book-sync: ## Synchronize book's linter vocabularies.
 	$(CONTAINER_TOOL) run --rm -v $(BOOK_PATH):/book -w /book jdkato/vale:$(VALE_VERSION) sync
 
 .PHONY: lint-book
-lint-book: lint-book-sync
+lint-book: lint-book-sync ## Lint the book.
 	$(CONTAINER_TOOL) run --rm -v $(BOOK_PATH):/book -w /book jdkato/vale:$(VALE_VERSION) /book/src
 
+##@ Development
+
 .PHONY: vet
-vet:
+vet: ## run go vet on all projects. Failures are ignored.
 	-$(MAKE) -C $(E2E_FOLDER) vet
 	-$(MAKE) -C $(OPERATOR_FOLDER) vet
 	-$(MAKE) -C $(SERVER_FOLDER) vet
 
 .PHONY: unit-test
-unit-test:
+unit-test: ## run go test on all projects.
 	@printf "%s " $(call text-style, setaf 2 bold, "run Operator's unit tests:")
 	$(MAKE) -C $(OPERATOR_FOLDER) test
 	@printf "\n%s " $(call text-style, setaf 2 bold, "run Server's unit tests:")

--- a/operator/Makefile
+++ b/operator/Makefile
@@ -19,14 +19,9 @@ endif
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
-.PHONY: all
-all: build
-
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 OUTDIR := $(ROOT_DIR)/out
-$(OUTDIR):
-	@mkdir $(OUTDIR)
 
 ##@ General
 
@@ -44,6 +39,13 @@ $(OUTDIR):
 .PHONY: help
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
+
+
+## Local Folder
+
+$(OUTDIR):
+	@mkdir $(OUTDIR)
+
 
 ##@ Development
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,11 +1,7 @@
 ROOT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 LOCALBIN := $(ROOT_DIR)/bin
-$(LOCALBIN):
-	mkdir $(LOCALBIN)
 
 OUTDIR := $(ROOT_DIR)/out
-$(OUTDIR):
-	@mkdir $(OUTDIR)
 
 GO ?= go
 LD_FLAGS ?= -s -w
@@ -45,35 +41,12 @@ JWKS_URL := https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-c
 help: ## Display this help.
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-##@ Dependencies
+## Local Folders
+$(LOCALBIN):
+	mkdir $(LOCALBIN)
+$(OUTDIR):
+	@mkdir $(OUTDIR)
 
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE)
-$(KUSTOMIZE):
-	test -s $(LOCALBIN)/kustomize || \
-		$(GO) build \
-			-modfile $(shell dirname $(ROOT_DIR))/hack/tools/kustomize/go.mod \
-			-o $(LOCALBIN)/kustomize \
-			sigs.k8s.io/kustomize/kustomize/v5
-
-.PHONY: mockgen
-mockgen: $(MOCKGEN)
-$(MOCKGEN): $(LOCALBIN)
-	@cp hack/tools/mockgen $(LOCALBIN)/
-
-.PHONY: yq
-yq: $(YQ)
-$(YQ): $(LOCALBIN)
-	$(GO) build \
-		-modfile $(shell dirname $(ROOT_DIR))/hack/tools/yq/go.mod \
-		-o $(LOCALBIN)/yq \
-		github.com/mikefarah/yq/v4
-
-.PHONY: controller-gen
-controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
-$(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
-	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
 ##@ Development
 
@@ -85,61 +58,98 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
 	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
 
+.PHONY: generate-code
+generate-code: mockgen  ## Run go generate on the project.
+	@echo $(GO) generate ./...
+	@PATH=$(ROOT_DIR)/bin:${PATH} $(GO) generate ./...
+
 .PHONY: clean
-clean:
+clean: ## Delete local folders.
 	@-rm -r $(LOCALBIN)
 	@-rm -r $(OUTDIR)
 
+.PHONY: lint
+lint: ## Run go linter.
+	$(GOLANG_CI) run ./...
+
+.PHONY: vet
+vet: ## Run go vet against code.
+	$(GO) vet ./...
+
+.PHONY: fmt
+fmt: ## Run go fmt against code.
+	$(GO) fmt ./...
+
+.PHONY: test
+test: generate-code ## Run tests.
+	$(GO) test ./...
+
+.PHONY: test-with-coverage
+test-with-coverage: generate-code ## Run tests with coverage.
+	$(GO) test ./... -covermode=atomic -coverprofile cover.out
+
+
+##@ Build 
+
 .PHONY: build
-build:
+build: ## Build server binary.
 	@$(GO) build \
 		-ldflags '$(LD_FLAGS)' \
 		-trimpath \
 		-o $(LOCALBIN)/server \
 		main.go
 
-.PHONY: generate-code
-generate-code: mockgen
-	@echo $(GO) generate ./...
-	@PATH=$(ROOT_DIR)/bin:${PATH} $(GO) generate ./...
-
 .PHONY: run
-run:
+run: ## Run the server from your host.
 	$(GO) run main.go
 
-.PHONY: lint
-lint:
-	$(GOLANG_CI) run ./...
-
-.PHONY: vet
-vet:
-	$(GO) vet ./...
-
-.PHONY: fmt
-fmt:
-	$(GO) fmt ./...
-
-.PHONY: test
-test: generate-code
-	$(GO) test ./...
-
-.PHONY: test-with-coverage
-test-with-coverage: generate-code
-	$(GO) test ./... -covermode=atomic -coverprofile cover.out
-
 .PHONY: docker-build
-docker-build:
+docker-build: ## Build docker image.
 	$(IMAGE_BUILDER) build -t ${IMG} -f Dockerfile ..
 
+
+##@ Deployment
+
 .PHONY: deploy
-deploy: kustomize yq
+deploy: kustomize yq  ## Deploy server.
 	YQ="$(YQ)" KUSTOMIZE="$(KUSTOMIZE)" ./hack/deploy.sh "$(NAMESPACE)" "$(IMG)"
 
 .PHONY: package
-package: kustomize yq $(OUTDIR)
+package: kustomize yq $(OUTDIR) ## Package server for release.
 	JWKS_URL="$(JWKS_URL)" \
 			 TOOLCHAIN_HOST="toolchain-host-operator" \
 			 YQ="$(YQ)" \
 			 KUSTOMIZE="$(KUSTOMIZE)" \
 			 MANIFEST_TARBALL="$(MANIFEST_TARBALL)" \
 			 ./hack/deploy.sh "$(NAMESPACE)" "$(IMG)"
+
+
+##@ Build Dependencies
+
+.PHONY: controller-gen
+controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
+$(CONTROLLER_GEN): $(LOCALBIN)
+	test -s $(LOCALBIN)/controller-gen && $(LOCALBIN)/controller-gen --version | grep -q $(CONTROLLER_TOOLS_VERSION) || \
+	GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
+
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary. If wrong version is installed, it will be overwritten.
+$(KUSTOMIZE):
+	test -s $(LOCALBIN)/kustomize || \
+		$(GO) build \
+			-modfile $(shell dirname $(ROOT_DIR))/hack/tools/kustomize/go.mod \
+			-o $(LOCALBIN)/kustomize \
+			sigs.k8s.io/kustomize/kustomize/v5
+
+.PHONY: mockgen
+mockgen: $(MOCKGEN) ## Install mockgen locally.
+$(MOCKGEN): $(LOCALBIN)
+	@cp hack/tools/mockgen $(LOCALBIN)/
+
+.PHONY: yq
+yq: $(YQ) ## Download yq locally if necessary. If wrong version is installed, it will be overwritten.
+$(YQ): $(LOCALBIN)
+	$(GO) build \
+		-modfile $(shell dirname $(ROOT_DIR))/hack/tools/yq/go.mod \
+		-o $(LOCALBIN)/yq \
+		github.com/mikefarah/yq/v4


### PR DESCRIPTION
<details>
<summary><code>make [help]</code></summary>

```
Usage:
  make <target>

General
  help             Display this help.

Book
  book             Build the book.
  lint-book-sync   Synchronize book's linter vocabularies.
  lint-book        Lint the book.

Development
  vet              run go vet on all projects. Failures are ignored.
  unit-test        run go test on all projects.
```
</details>

<details>
<summary><code>make -C server [help]</code></summary>

```
Usage:
  make <target>

General
  help             Display this help.

Development
  manifests        Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
  generate         Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
  generate-code    Run go generate on the project.
  clean            Delete local folders.
  lint             Run go linter.
  vet              Run go vet against code.
  fmt              Run go fmt against code.
  test             Run tests.
  test-with-coverage  Run tests with coverage.

Build
  build            Build server binary.
  run              Run the server from your host.
  docker-build     Build docker image.

Deployment
  deploy           Deploy server.
  package          Package server for release.

Build Dependencies
  controller-gen   Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
  kustomize        Download kustomize locally if necessary. If wrong version is installed, it will be overwritten.
  mockgen          Install mockgen locally.
  yq               Download yq locally if necessary. If wrong version is installed, it will be overwritten.
```
</details>

<details>
<summary><code>make -C operator [help]</code></summary>

```
Usage:
  make <target>

General
  help             Display this help.

Development
  manifests        Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
  generate         Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
  fmt              Run go fmt against code.
  vet              Run go vet against code.
  test             Run tests.

Build
  build            Build manager binary.
  run              Run a controller from your host.
  docker-build     Build docker image with the manager.
  docker-push      Push docker image with the manager.
  docker-buildx    Build and push docker image for the manager for cross-platform support

Deployment
  install          Install CRDs into the K8s cluster specified in ~/.kube/config.
  uninstall        Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
  deploy           Deploy controller to the K8s cluster specified in ~/.kube/config.
  undeploy         Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.

Build Dependencies
  kustomize        Download kustomize locally if necessary. If wrong version is installed, it will be removed before downloading.
  controller-gen   Download controller-gen locally if necessary. If wrong version is installed, it will be overwritten.
  envtest          Download envtest-setup locally if necessary.
```

</details>

Signed-off-by: Francesco Ilario <filario@redhat.com>
