### PR TITLE
ci: use latest ksctl during kubesaw deployment

### DIFF
--- a/ci/toolchain_manager.sh
+++ b/ci/toolchain_manager.sh
@@ -52,6 +52,7 @@ function deploy {
         FORCED_TAG="${TAG}" \
         QUAY_NAMESPACE="${QUAY_NAMESPACE}" \
         SECOND_MEMBER_MODE=false \
+        CI_DISABLE_PAIRING=true \
         CI=true \
         REG_REPO_PATH=../registration-service \
         HOST_REPO_PATH=../host-operator \


### PR DESCRIPTION
See these PRs for context:

- https://github.com/codeready-toolchain/toolchain-e2e/pull/1034
- https://github.com/codeready-toolchain/toolchain-e2e/pull/1041
- https://github.com/redhat-appstudio/infra-deployments/pull/4324

This is needed if we want to use `ci/toolchain-manager.sh` outside of CI environments.