### PR TITLE
dependabot: add group for ginkgo & gomega

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,12 @@ updates:
     kubernetes:
       patterns:
       - "k8s.io/*"
+    ginkgo:
+      patterns:
+      - "github.com/onsi/ginkgo/v2"
+    gomega:
+      patterns:
+      - "github.com/onsi/gomega"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
Both of these usually need to be keep in sync across our entire repository due to testing needs.