### PR TITLE
smoke: some simple fixes

### DIFF
--- a/hack/smoke.sh
+++ b/hack/smoke.sh
@@ -90,7 +90,7 @@ check_command jq
 
 RESPONSE=$(curl --oauth2-bearer "${TOKEN}" -sSfL "${CLUSTER_URL}/api/k8s/apis/workspaces.konflux-ci.dev/v1alpha1/workspaces")
 ARGS=".items[] | select(.metadata.namespace == \"${USERNAME}\")"
-OUTPUT="$(echo "${RESPONSE}" | jq "${ARGS}")"
+OUTPUT=$(jq "${ARGS}" <<< "${RESPONSE}")
 if [[ "${OUTPUT}" = "" ]]; then
     LOG_FILE="${TMPDIR:-/tmp}/workspaces.$(date +%s)"
 

--- a/hack/smoke.sh
+++ b/hack/smoke.sh
@@ -87,11 +87,10 @@ fi
 
 check_command curl
 check_command jq
-check_command mktemp
 
 RESPONSE=$(curl --oauth2-bearer "${TOKEN}" -sSfL "${CLUSTER_URL}/api/k8s/apis/workspaces.konflux-ci.dev/v1alpha1/workspaces")
 ARGS=".items[] | select(.metadata.namespace == \"${USERNAME}\")"
-OUTPUT="$(jq "${ARGS}" "${RESPONSE}")"
+OUTPUT="$(echo "${RESPONSE}" | jq "${ARGS}")"
 if [[ "${OUTPUT}" = "" ]]; then
     LOG_FILE="${TMPDIR:-/tmp}/workspaces.$(date +%s)"
 
@@ -101,3 +100,5 @@ if [[ "${OUTPUT}" = "" ]]; then
 
     exit 1
 fi
+
+echo "Smoke tests succeeded!"


### PR DESCRIPTION
This changes the following:

- removes a false dependency on `mktemp`
- prints a message when tests pass
- passes data to jq in a way it can understand