### PR TITLE
update traefik to v3.1.2

### DIFF
--- a/server/config/server/deployment.yaml
+++ b/server/config/server/deployment.yaml
@@ -18,7 +18,7 @@ spec:
       securityContext:
         runAsNonRoot: true
       containers:
-      - image: traefik:v2.11.0
+      - image: traefik:v3.1.2
         name: proxy
         imagePullPolicy: IfNotPresent
         volumeMounts:


### PR DESCRIPTION
We'll need to cut a release next week to roll this out to infra-deployments.