### PR TITLE
smoke: fix writing log file

### DIFF
--- a/hack/smoke.sh
+++ b/hack/smoke.sh
@@ -96,7 +96,7 @@ if [[ "${OUTPUT}" = "" ]]; then
 
     echo "Failed to find default namespace for user \"${USERNAME}\"!"
     echo "${RESPONSE}" > "${LOG_FILE}"
-    echo "Response output saved in ${RESPONSE}"
+    echo "Response output saved in ${LOG_FILE}"
 
     exit 1
 fi


### PR DESCRIPTION
We were writing the log file to "${RESPONSE}", not "${LOG_FILE}", which made for invalid file names.