### PR TITLE
add workspaces/operator in dependabot for indirect deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,11 @@ updates:
     ginkgo:
       patterns:
       - "github.com/onsi/ginkgo/v2"
+      - "github.com/konflux-workspaces/workspaces/operator"
     gomega:
       patterns:
       - "github.com/onsi/gomega"
+      - "github.com/konflux-workspaces/workspaces/operator"
   schedule:
     interval: weekly
   open-pull-requests-limit: 10


### PR DESCRIPTION
This change wants to force the update of `e2e`'s indirect dependencies related to ginkgo and gomega when they are updated in `operator`.

Look at #282 and #283 for examples of the problem. When gomega or ginkgo are updated in `operator`, they are not updated in `e2e` as they are indirect dependencies. As a consequence the build fails due to untidied gomod.

Alternatively, we can add ginkgo and gomega as `e2e`'s direct dependencies. I think it would be good to start using gomega `e2e`, but I don't see space for ginkgo at the moment.
