### PR TITLE
operator: expose metrics endpoint as a service

### DIFF
--- a/operator/config/default/kustomization.yaml
+++ b/operator/config/default/kustomization.yaml
@@ -6,5 +6,6 @@ resources:
 - ../crd
 - ../rbac
 - ../manager
+- metrics-service.yaml
 patches:
 - path: manager_auth_proxy_patch.yaml

--- a/operator/config/default/metrics-service.yaml
+++ b/operator/config/default/metrics-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: controller-manager-metrics
+  namespace: system
+spec:
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 8080
+  selector:
+    control-plane: controller-manager
+  type: ClusterIP
+  sessionAffinity: None


### PR DESCRIPTION
It already exists, we just need to expose it.