### PR TITLE
Make calls to mktemp compatible with mac

### DIFF
--- a/ci/toolchain_manager.sh
+++ b/ci/toolchain_manager.sh
@@ -80,7 +80,7 @@ function usage {
 
 function use_tmp_dir {
     # create a temporary direction
-    f=$(mktemp --directory /tmp/toolchain.XXXX)
+    f=$(mktemp -d /tmp/toolchain.XXXX)
     cd "${f}"
 }
 

--- a/e2e/Makefile
+++ b/e2e/Makefile
@@ -35,7 +35,7 @@ push-images:
 .PHONY: deploy-operator
 deploy-operator:
 	(\
-		f=$$(mktemp --directory /tmp/workspaces-config.XXXXX) && \
+		f=$$(mktemp -d /tmp/workspaces-config.XXXXX) && \
 		cp -r "../hack" "../operator" "../server" "$$f" && \
 		cd "$$f/operator" && \
 		( \

--- a/hack/workspaces_install.sh
+++ b/hack/workspaces_install.sh
@@ -4,7 +4,7 @@ set -e
 
 export QUAY_NAMESPACE=${QUAY_NAMESPACE:-konflux-workspaces}
 
-f=$(mktemp --directory /tmp/workspaces-demo.XXXX)
+f=$(mktemp -d /tmp/workspaces-demo.XXXX)
 
 cp -r hack/ operator/ e2e/ server/ "${f}"
 cd "${f}"

--- a/server/hack/deploy.sh
+++ b/server/hack/deploy.sh
@@ -24,7 +24,7 @@ if [[ -z "${TOOLCHAIN_HOST}" ]]; then
 fi
 
 # prepare temporary folder
-f=$(mktemp --directory /tmp/workspaces-rest.XXXXX)
+f=$(mktemp -d /tmp/workspaces-rest.XXXXX)
 cp -r "${ROOT_DIR}/server/config" "${f}/config"
 cd "${f}/config/default"
 


### PR DESCRIPTION
Mac does not support --directory but it does support short version -d as well as Fedora