### PR TITLE
add labels indicating access

### DIFF
--- a/server/api/v1alpha1/workspace_types.go
+++ b/server/api/v1alpha1/workspace_types.go
@@ -29,8 +29,11 @@ const (
 	// WorkspaceVisibilityPrivate Private value for Workspaces visibility
 	WorkspaceVisibilityPrivate WorkspaceVisibility = "private"
 
-	// LabelInternalDomain if the requesting user is the owner of the workspace
+	// LabelIsOwner if the requesting user is the owner of the workspace
 	LabelIsOwner string = workspacesv1alpha1.LabelInternalDomain + "is-owner"
+	// LabelHasDirectAccess if the requesting user has access to the workspace
+	// via a direct grant or via public-viewer
+	LabelHasDirectAccess string = workspacesv1alpha1.LabelInternalDomain + "has-direct-access"
 )
 
 // WorkspaceSpec defines the desired state of Workspace

--- a/server/persistence/clientinterface/readclient.go
+++ b/server/persistence/clientinterface/readclient.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2024 The Workspaces Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clientinterface
+
+import (
+	"context"
+
+	workspacesv1alpha1 "github.com/konflux-workspaces/workspaces/operator/api/v1alpha1"
+	restworkspacesv1alpha1 "github.com/konflux-workspaces/workspaces/server/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// SpaceKey comprises a Space name, with a mandatory owner.
+type SpaceKey struct {
+	Owner string
+	Name  string
+}
+
+// InternalWorkspacesReader is the definition for a InternalWorkspaces Read Client
+type InternalWorkspacesReader interface {
+	GetAsUser(context.Context, string, SpaceKey, *workspacesv1alpha1.InternalWorkspace, ...client.GetOption) error
+	ListAsUser(context.Context, string, *workspacesv1alpha1.InternalWorkspaceList) error
+}
+
+// InternalWorkspacesMapper is the definition for a InternalWorkspaces/Workspaces Mapper
+type InternalWorkspacesMapper interface {
+	InternalWorkspaceListToWorkspaceList(*workspacesv1alpha1.InternalWorkspaceList) (*restworkspacesv1alpha1.WorkspaceList, error)
+	InternalWorkspaceToWorkspace(*workspacesv1alpha1.InternalWorkspace) (*restworkspacesv1alpha1.Workspace, error)
+	WorkspaceToInternalWorkspace(*restworkspacesv1alpha1.Workspace) (*workspacesv1alpha1.InternalWorkspace, error)
+}
+
+type DirectAccessChecker interface {
+	UserHasDirectAccess(context.Context, string, string) (bool, error)
+}
+
+type InternalWorkspacesReadClient interface {
+	InternalWorkspacesReader
+	DirectAccessChecker
+}

--- a/server/persistence/iwclient/iwclient.go
+++ b/server/persistence/iwclient/iwclient.go
@@ -6,13 +6,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
+	"github.com/konflux-workspaces/workspaces/server/persistence/clientinterface"
+	"github.com/konflux-workspaces/workspaces/server/persistence/mapper"
 )
 
-// SpaceKey comprises a Space name, with a mandatory owner.
-type SpaceKey struct {
-	Owner string
-	Name  string
-}
+var (
+	_ clientinterface.InternalWorkspacesReadClient = &Client{}
+	_ clientinterface.InternalWorkspacesMapper     = mapper.Default
+)
 
 type Client struct {
 	backend client.Reader
@@ -30,7 +31,7 @@ func New(backend client.Reader, workspacesNamespace, kubesawNamespace string) *C
 	}
 }
 
-func (c *Client) existsSpaceBindingForUserAndSpace(ctx context.Context, user, space string) (bool, error) {
+func (c *Client) UserHasDirectAccess(ctx context.Context, user, space string) (bool, error) {
 	ml := client.MatchingLabels{
 		toolchainv1alpha1.SpaceBindingMasterUserRecordLabelKey: user,
 		toolchainv1alpha1.SpaceBindingSpaceLabelKey:            space,

--- a/server/persistence/iwclient/iwclient_read.go
+++ b/server/persistence/iwclient/iwclient_read.go
@@ -7,6 +7,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/konflux-workspaces/workspaces/server/log"
+	"github.com/konflux-workspaces/workspaces/server/persistence/clientinterface"
 	"github.com/konflux-workspaces/workspaces/server/persistence/internal/cache"
 
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
@@ -23,7 +24,7 @@ var (
 func (c *Client) GetAsUser(
 	ctx context.Context,
 	user string,
-	key SpaceKey,
+	key clientinterface.SpaceKey,
 	workspace *workspacesv1alpha1.InternalWorkspace,
 	opts ...client.GetOption,
 ) error {
@@ -44,7 +45,7 @@ func (c *Client) GetAsUser(
 
 	// check if user has direct visibility on the space
 	l.Debug("InternalWorkspace is private, checking for a SpaceBinding for the user")
-	ok, err := c.existsSpaceBindingForUserAndSpace(ctx, user, w.GetName())
+	ok, err := c.UserHasDirectAccess(ctx, user, w.GetName())
 	if err != nil {
 		l.Error("error retrieving SpaceBindings for InternalWorkspace", "error", err)
 		return err

--- a/server/persistence/iwclient/iwclient_read_test.go
+++ b/server/persistence/iwclient/iwclient_read_test.go
@@ -12,6 +12,7 @@ import (
 	toolchainv1alpha1 "github.com/codeready-toolchain/api/api/v1alpha1"
 	workspacesv1alpha1 "github.com/konflux-workspaces/workspaces/operator/api/v1alpha1"
 
+	"github.com/konflux-workspaces/workspaces/server/persistence/clientinterface"
 	"github.com/konflux-workspaces/workspaces/server/persistence/iwclient"
 )
 
@@ -47,7 +48,7 @@ var _ = Describe("Read", func() {
 		It("should not return the workspace in read", func() {
 			// when
 			var w workspacesv1alpha1.InternalWorkspace
-			key := iwclient.SpaceKey{Owner: "owner", Name: "no-space-binding"}
+			key := clientinterface.SpaceKey{Owner: "owner", Name: "no-space-binding"}
 			err := c.GetAsUser(ctx, "owner", key, &w)
 
 			// then
@@ -85,7 +86,7 @@ var _ = Describe("Read", func() {
 		It("should not return the workspace in read", func() {
 			// when
 			var w workspacesv1alpha1.InternalWorkspace
-			key := iwclient.SpaceKey{Owner: "owner", Name: "no-label"}
+			key := clientinterface.SpaceKey{Owner: "owner", Name: "no-label"}
 			err := c.GetAsUser(ctx, "owner", key, &w)
 
 			// then
@@ -150,7 +151,7 @@ var _ = Describe("Read", func() {
 		It("should be returned in read", func() {
 			// when
 			var rw workspacesv1alpha1.InternalWorkspace
-			key := iwclient.SpaceKey{Owner: "owner-user", Name: "owner-ws"}
+			key := clientinterface.SpaceKey{Owner: "owner-user", Name: "owner-ws"}
 			err := c.GetAsUser(ctx, "owner-user", key, &rw)
 
 			// then
@@ -161,7 +162,7 @@ var _ = Describe("Read", func() {
 		It("should NOT be returned in read of not-owner-user workspace", func() {
 			// when
 			rw := workspacesv1alpha1.InternalWorkspace{}
-			key := iwclient.SpaceKey{Owner: "owner-user", Name: "owner-ws"}
+			key := clientinterface.SpaceKey{Owner: "owner-user", Name: "owner-ws"}
 			err := c.GetAsUser(ctx, "not-owner-user", key, &rw)
 
 			// then
@@ -242,7 +243,7 @@ var _ = Describe("Read", func() {
 			for _, w := range ww {
 				// when
 				var rw workspacesv1alpha1.InternalWorkspace
-				key := iwclient.SpaceKey{Owner: w.Status.Owner.Username, Name: w.Spec.DisplayName}
+				key := clientinterface.SpaceKey{Owner: w.Status.Owner.Username, Name: w.Spec.DisplayName}
 				err := c.GetAsUser(ctx, w.Status.Owner.Username, key, &rw)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -255,7 +256,7 @@ var _ = Describe("Read", func() {
 			for _, w := range ww {
 				// when
 				rw := workspacesv1alpha1.InternalWorkspace{}
-				key := iwclient.SpaceKey{Owner: w.Status.Owner.Username, Name: w.Spec.DisplayName}
+				key := clientinterface.SpaceKey{Owner: w.Status.Owner.Username, Name: w.Spec.DisplayName}
 				err := c.GetAsUser(ctx, "not-owner-user", key, &rw)
 
 				// then
@@ -340,7 +341,7 @@ var _ = Describe("Read", func() {
 		It("is returned in read", func() {
 			// when
 			var w workspacesv1alpha1.InternalWorkspace
-			key := iwclient.SpaceKey{Owner: "owner-user", Name: wName}
+			key := clientinterface.SpaceKey{Owner: "owner-user", Name: wName}
 			err := c.GetAsUser(ctx, "owner-user", key, &w)
 
 			// then
@@ -408,7 +409,7 @@ var _ = Describe("Read", func() {
 		It("is returned in other-user's read", func() {
 			// when
 			var w workspacesv1alpha1.InternalWorkspace
-			key := iwclient.SpaceKey{Owner: "owner-user", Name: wName}
+			key := clientinterface.SpaceKey{Owner: "owner-user", Name: wName}
 			err := c.GetAsUser(ctx, "other-user", key, &w)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/server/persistence/readclient/interface_test.go
+++ b/server/persistence/readclient/interface_test.go
@@ -1,13 +1,15 @@
 package readclient_test
 
-import "github.com/konflux-workspaces/workspaces/server/persistence/readclient"
+import (
+	"github.com/konflux-workspaces/workspaces/server/persistence/clientinterface"
+)
 
 //go:generate mockgen -source=interface_test.go -destination=mocks/readclient.go -package=mocks -exclude_interfaces=FakeIWMapper
 type FakeIWReadClient interface {
-	readclient.InternalWorkspacesReadClient
+	clientinterface.InternalWorkspacesReadClient
 }
 
 //go:generate mockgen -source=interface_test.go -destination=mocks/mapper.go -package=mocks -exclude_interfaces=FakeIWReadClient
 type FakeIWMapper interface {
-	readclient.InternalWorkspacesMapper
+	clientinterface.InternalWorkspacesMapper
 }

--- a/server/persistence/readclient/mocks/readclient.go
+++ b/server/persistence/readclient/mocks/readclient.go
@@ -14,7 +14,7 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/konflux-workspaces/workspaces/operator/api/v1alpha1"
-	iwclient "github.com/konflux-workspaces/workspaces/server/persistence/iwclient"
+	clientinterface "github.com/konflux-workspaces/workspaces/server/persistence/clientinterface"
 	gomock "go.uber.org/mock/gomock"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -43,7 +43,7 @@ func (m *MockFakeIWReadClient) EXPECT() *MockFakeIWReadClientMockRecorder {
 }
 
 // GetAsUser mocks base method.
-func (m *MockFakeIWReadClient) GetAsUser(arg0 context.Context, arg1 string, arg2 iwclient.SpaceKey, arg3 *v1alpha1.InternalWorkspace, arg4 ...client.GetOption) error {
+func (m *MockFakeIWReadClient) GetAsUser(arg0 context.Context, arg1 string, arg2 clientinterface.SpaceKey, arg3 *v1alpha1.InternalWorkspace, arg4 ...client.GetOption) error {
 	m.ctrl.T.Helper()
 	varargs := []any{arg0, arg1, arg2, arg3}
 	for _, a := range arg4 {
@@ -73,4 +73,19 @@ func (m *MockFakeIWReadClient) ListAsUser(arg0 context.Context, arg1 string, arg
 func (mr *MockFakeIWReadClientMockRecorder) ListAsUser(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAsUser", reflect.TypeOf((*MockFakeIWReadClient)(nil).ListAsUser), arg0, arg1, arg2)
+}
+
+// UserHasDirectAccess mocks base method.
+func (m *MockFakeIWReadClient) UserHasDirectAccess(arg0 context.Context, arg1, arg2 string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UserHasDirectAccess", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UserHasDirectAccess indicates an expected call of UserHasDirectAccess.
+func (mr *MockFakeIWReadClientMockRecorder) UserHasDirectAccess(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserHasDirectAccess", reflect.TypeOf((*MockFakeIWReadClient)(nil).UserHasDirectAccess), arg0, arg1, arg2)
 }

--- a/server/persistence/readclient/readclient.go
+++ b/server/persistence/readclient/readclient.go
@@ -5,39 +5,18 @@ import (
 
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/konflux-workspaces/workspaces/server/persistence/clientinterface"
 	icache "github.com/konflux-workspaces/workspaces/server/persistence/internal/cache"
 	"github.com/konflux-workspaces/workspaces/server/persistence/iwclient"
 	"github.com/konflux-workspaces/workspaces/server/persistence/mapper"
-
-	workspacesv1alpha1 "github.com/konflux-workspaces/workspaces/operator/api/v1alpha1"
-	restworkspacesv1alpha1 "github.com/konflux-workspaces/workspaces/server/api/v1alpha1"
 )
-
-var (
-	_ InternalWorkspacesReadClient = &iwclient.Client{}
-	_ InternalWorkspacesMapper     = mapper.Default
-)
-
-// InternalWorkspacesReadClient is the definition for a InternalWorkspaces Read Client
-type InternalWorkspacesReadClient interface {
-	GetAsUser(context.Context, string, iwclient.SpaceKey, *workspacesv1alpha1.InternalWorkspace, ...client.GetOption) error
-	ListAsUser(context.Context, string, *workspacesv1alpha1.InternalWorkspaceList) error
-}
-
-// InternalWorkspacesMapper is the definition for a InternalWorkspaces/Workspaces Mapper
-type InternalWorkspacesMapper interface {
-	InternalWorkspaceListToWorkspaceList(*workspacesv1alpha1.InternalWorkspaceList) (*restworkspacesv1alpha1.WorkspaceList, error)
-	InternalWorkspaceToWorkspace(*workspacesv1alpha1.InternalWorkspace) (*restworkspacesv1alpha1.Workspace, error)
-	WorkspaceToInternalWorkspace(*restworkspacesv1alpha1.Workspace) (*workspacesv1alpha1.InternalWorkspace, error)
-}
 
 // ReadClient implements the WorkspaceLister and WorkspaceReader interfaces
 // using a client.Reader as backend
 type ReadClient struct {
-	internalClient InternalWorkspacesReadClient
-	mapper         InternalWorkspacesMapper
+	internalClient clientinterface.InternalWorkspacesReadClient
+	mapper         clientinterface.InternalWorkspacesMapper
 }
 
 // NewDefaultWithCache creates a controller-runtime cache and use it as KubeReadClient's backend.
@@ -53,12 +32,12 @@ func NewDefaultWithCache(ctx context.Context, cfg *rest.Config, workspacesNamesp
 }
 
 // NewDefaultWithInternalClient creates a new KubeReadClient with the provided backend and default InternalWorkspaces/Workspaces mapper
-func NewDefaultWithInternalClient(internalClient InternalWorkspacesReadClient) *ReadClient {
+func NewDefaultWithInternalClient(internalClient clientinterface.InternalWorkspacesReadClient) *ReadClient {
 	return New(internalClient, mapper.Default)
 }
 
 // New creates a new KubeReadClient with the provided backend and a custom InternalWorkspaces/Workspaces mapper
-func New(internalClient InternalWorkspacesReadClient, mapper InternalWorkspacesMapper) *ReadClient {
+func New(internalClient clientinterface.InternalWorkspacesReadClient, mapper clientinterface.InternalWorkspacesMapper) *ReadClient {
 	return &ReadClient{
 		internalClient: internalClient,
 		mapper:         mapper,

--- a/server/persistence/readclient/readclient_list.go
+++ b/server/persistence/readclient/readclient_list.go
@@ -51,9 +51,16 @@ func (c *ReadClient) ListUserWorkspaces(
 	// filter by namespace
 	filterByNamespace(ww, listOpts.Namespace)
 
-	// apply is-owner label
 	for i := range ww.Items {
+		// apply is-owner label
+		// TODO(sadlerap): merge these into a single applier method?
 		mutate.ApplyIsOwnerLabel(&ww.Items[i], user)
+
+		// apply has-direct-access label
+		err := mutate.ApplyHasDirectAccessLabel(ctx, c.internalClient, &ww.Items[i], user)
+		if err != nil {
+			return kerrors.NewInternalError(fmt.Errorf("error retrieving the list of workspaces for user %v", user))
+		}
 	}
 
 	ww.DeepCopyInto(objs)

--- a/server/persistence/writeclient/writeclient_create.go
+++ b/server/persistence/writeclient/writeclient_create.go
@@ -45,6 +45,8 @@ func (c *WriteClient) CreateUserWorkspace(ctx context.Context, user string, work
 
 	// apply the is-owner label
 	mutate.ApplyIsOwnerLabel(w, user)
+	// if a user is creating a workspace, then they must have direct access to it
+	w.Labels[restworkspacesv1alpha1.LabelHasDirectAccess] = "true"
 
 	// fill return value
 	w.DeepCopyInto(workspace)

--- a/server/persistence/writeclient/writeclient_create_test.go
+++ b/server/persistence/writeclient/writeclient_create_test.go
@@ -100,7 +100,7 @@ var _ = Describe("WriteclientCreate", func() {
 	})
 
 	When("creating an owned workspace", func() {
-		It("should have the is-owner label", func() {
+		It("should have appropriate labels set", func() {
 			// given
 			workspace.Spec.Visibility = restworkspacesv1alpha1.WorkspaceVisibilityPrivate
 
@@ -109,7 +109,9 @@ var _ = Describe("WriteclientCreate", func() {
 
 			// then
 			Expect(err).NotTo(HaveOccurred())
-			Expect(workspace.Labels).To(HaveKeyWithValue(restworkspacesv1alpha1.LabelIsOwner, "true"))
+			Expect(workspace.Labels).To(And(
+				HaveKeyWithValue(restworkspacesv1alpha1.LabelIsOwner, "true"),
+				HaveKeyWithValue(restworkspacesv1alpha1.LabelHasDirectAccess, "true")))
 			validateCreatedInternalWorkspace(&workspace, workspacesv1alpha1.InternalWorkspaceVisibilityPrivate)
 		})
 	})

--- a/server/persistence/writeclient/writeclient_update_test.go
+++ b/server/persistence/writeclient/writeclient_update_test.go
@@ -170,7 +170,6 @@ var _ = Describe("WriteclientUpdate", func() {
 			It("should update if the user is the owner", func() {
 				// given
 				w := workspace.DeepCopy()
-				w.Spec.Visibility = restworkspacesv1alpha1.WorkspaceVisibilityCommunity
 
 				// when
 				err := cli.UpdateUserWorkspace(ctx, user, w)
@@ -179,6 +178,7 @@ var _ = Describe("WriteclientUpdate", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(w.Labels).To(HaveKeyWithValue(restworkspacesv1alpha1.LabelIsOwner, "true"))
+				Expect(w.Labels).To(HaveKeyWithValue(restworkspacesv1alpha1.LabelHasDirectAccess, "true"))
 			})
 		})
 	})


### PR DESCRIPTION
When requesting workspaces through our server, we will now label them with the label `internal.workspaces.konflux-ci.dev/is-owner`.  This label will either be set to `true` or `false` depending on whether the requesting user is an owner or not.

This label is set for all operations - get, list, create, and update.