### PR TITLE
operator: don't generate data field for metrics-reader secret

### DIFF
--- a/operator/config/metrics/kustomization.yaml
+++ b/operator/config/metrics/kustomization.yaml
@@ -4,8 +4,3 @@ resources:
 - monitor.yaml
 - service-account.yaml
 - metrics-service.yaml
-secretGenerator:
-- name: metrics-reader
-  type: "kubernetes.io/service-account-token"
-generatorOptions:
-  disableNameSuffixHash: true

--- a/operator/config/metrics/monitor.yaml
+++ b/operator/config/metrics/monitor.yaml
@@ -25,3 +25,10 @@ spec:
     matchLabels:
       control-plane: controller-manager
       app.kubernetes.io/component: metrics
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-reader
+  namespace: system
+type: kubernetes.io/service-account-token


### PR DESCRIPTION
ArgoCD gets thrown into an out-of-sync loop when the data field exists on the metrics-reader secret.  This is because the service account controller fills in the data field with all the information a service account secret needs, which conflicts with the empty data that ArgoCD expects.  This data field exists because kustomize's secret generator provides a data field by default, and it appears there isn't a way to disable this.

To resolve this, we need to move away from using the secret generator in our kustomization manifests and instead spell out the secret in our manifests directly.