### PR TITLE
bump gosec version in CI to master

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Run gosec
-        uses: securego/gosec@v2.20.0
+        uses: securego/gosec@master
         with:
           args: '-exclude=G601 -no-fail -fmt sarif -out gosec.sarif ./...'
 


### PR DESCRIPTION
[v2.21.2 is broken][1] for use within github actions, but the [latest commit][2] works.  Until a new release of gosec is made available, use the latest `master` version.

[1]: https://github.com/securego/gosec/issues/1219
[2]: https://github.com/securego/gosec/commit/5f3194b581979e508b0ba1ee22f1f1f85a314e16