### PR TITLE
add is-owner label

### DIFF
--- a/server/api/v1alpha1/workspace_types.go
+++ b/server/api/v1alpha1/workspace_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	workspacesv1alpha1 "github.com/konflux-workspaces/workspaces/operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -27,6 +28,9 @@ const (
 	WorkspaceVisibilityCommunity WorkspaceVisibility = "community"
 	// WorkspaceVisibilityPrivate Private value for Workspaces visibility
 	WorkspaceVisibilityPrivate WorkspaceVisibility = "private"
+
+	// LabelInternalDomain if the requesting user is the owner of the workspace
+	LabelIsOwner string = workspacesv1alpha1.LabelInternalDomain + "is-owner"
 )
 
 // WorkspaceSpec defines the desired state of Workspace

--- a/server/persistence/mapper/internalworkspace_to_workspace_test.go
+++ b/server/persistence/mapper/internalworkspace_to_workspace_test.go
@@ -91,9 +91,11 @@ func validateMappedWorkspace(w *restworkspacesv1alpha1.Workspace, from workspace
 	Expect(w).ToNot(BeNil())
 	Expect(w.GetName()).To(Equal(from.Spec.DisplayName))
 	Expect(w.GetNamespace()).To(Equal(from.Status.Owner.Username))
-	Expect(w.GetLabels()).To(HaveKey("expected-label"))
-	Expect(w.GetLabels()["expected-label"]).To(Equal("not-empty"))
-	Expect(w.GetLabels()).NotTo(HaveKey(workspacesv1alpha1.LabelInternalDomain + "not-expected-label"))
+	Expect(w.GetLabels()).To(And(
+		HaveKeyWithValue("expected-label", "not-empty"),
+		Not(HaveKey(restworkspacesv1alpha1.LabelIsOwner)),
+		Not(HaveKey(workspacesv1alpha1.LabelInternalDomain+"not-expected-label")),
+	))
 	Expect(w.Generation).To(Equal(int64(1)))
 	Expect(w.Spec).ToNot(BeNil())
 	Expect(w.Status).ToNot(BeNil())

--- a/server/persistence/mutate/owner.go
+++ b/server/persistence/mutate/owner.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2024 The Workspaces Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mutate
+
+import restworkspacesv1alpha1 "github.com/konflux-workspaces/workspaces/server/api/v1alpha1"
+
+// Applies the is-owner internal label to a workspace
+func ApplyIsOwnerLabel(workspace *restworkspacesv1alpha1.Workspace, owner string) {
+	// do nothing on an empty workspace
+	if workspace == nil {
+		return
+	}
+
+	if workspace.Labels == nil {
+		workspace.Labels = map[string]string{}
+	}
+
+	switch workspace.Namespace {
+	case owner:
+		workspace.Labels[restworkspacesv1alpha1.LabelIsOwner] = "true"
+	default:
+		workspace.Labels[restworkspacesv1alpha1.LabelIsOwner] = "false"
+	}
+}

--- a/server/persistence/readclient/readclient_list.go
+++ b/server/persistence/readclient/readclient_list.go
@@ -12,6 +12,7 @@ import (
 	workspacesv1alpha1 "github.com/konflux-workspaces/workspaces/operator/api/v1alpha1"
 	restworkspacesv1alpha1 "github.com/konflux-workspaces/workspaces/server/api/v1alpha1"
 	"github.com/konflux-workspaces/workspaces/server/core/workspace"
+	"github.com/konflux-workspaces/workspaces/server/persistence/mutate"
 )
 
 var _ workspace.WorkspaceLister = &ReadClient{}
@@ -49,6 +50,11 @@ func (c *ReadClient) ListUserWorkspaces(
 
 	// filter by namespace
 	filterByNamespace(ww, listOpts.Namespace)
+
+	// apply is-owner label
+	for i := range ww.Items {
+		mutate.ApplyIsOwnerLabel(&ww.Items[i], user)
+	}
 
 	ww.DeepCopyInto(objs)
 	return nil

--- a/server/persistence/readclient/readclient_read.go
+++ b/server/persistence/readclient/readclient_read.go
@@ -9,6 +9,7 @@ import (
 	"github.com/konflux-workspaces/workspaces/server/core/workspace"
 	"github.com/konflux-workspaces/workspaces/server/log"
 	"github.com/konflux-workspaces/workspaces/server/persistence/iwclient"
+	"github.com/konflux-workspaces/workspaces/server/persistence/mutate"
 
 	workspacesv1alpha1 "github.com/konflux-workspaces/workspaces/operator/api/v1alpha1"
 	restworkspacesv1alpha1 "github.com/konflux-workspaces/workspaces/server/api/v1alpha1"
@@ -38,6 +39,9 @@ func (c *ReadClient) ReadUserWorkspace(
 		l.Error("error mapping internal workspace to workspace as user", "error", err)
 		return kerrors.NewInternalError(err)
 	}
+
+	// apply is-owner label
+	mutate.ApplyIsOwnerLabel(r, user)
 
 	// return workspace
 	r.DeepCopyInto(obj)

--- a/server/persistence/writeclient/writeclient_create.go
+++ b/server/persistence/writeclient/writeclient_create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/konflux-workspaces/workspaces/server/core/workspace"
 	"github.com/konflux-workspaces/workspaces/server/log"
 	"github.com/konflux-workspaces/workspaces/server/persistence/mapper"
+	"github.com/konflux-workspaces/workspaces/server/persistence/mutate"
 
 	restworkspacesv1alpha1 "github.com/konflux-workspaces/workspaces/server/api/v1alpha1"
 )
@@ -41,6 +42,9 @@ func (c *WriteClient) CreateUserWorkspace(ctx context.Context, user string, work
 	if err != nil {
 		return err
 	}
+
+	// apply the is-owner label
+	mutate.ApplyIsOwnerLabel(w, user)
 
 	// fill return value
 	w.DeepCopyInto(workspace)

--- a/server/persistence/writeclient/writeclient_create_test.go
+++ b/server/persistence/writeclient/writeclient_create_test.go
@@ -85,7 +85,7 @@ var _ = Describe("WriteclientCreate", func() {
 		})
 	})
 
-	When("creating a community workspace", func() {
+	When("creating a private workspace", func() {
 		It("should create workspaces using the given client", func() {
 			// given
 			workspace.Spec.Visibility = restworkspacesv1alpha1.WorkspaceVisibilityPrivate
@@ -95,6 +95,21 @@ var _ = Describe("WriteclientCreate", func() {
 
 			// then
 			Expect(err).NotTo(HaveOccurred())
+			validateCreatedInternalWorkspace(&workspace, workspacesv1alpha1.InternalWorkspaceVisibilityPrivate)
+		})
+	})
+
+	When("creating an owned workspace", func() {
+		It("should have the is-owner label", func() {
+			// given
+			workspace.Spec.Visibility = restworkspacesv1alpha1.WorkspaceVisibilityPrivate
+
+			// when
+			err := cli.CreateUserWorkspace(ctx, "owner", &workspace)
+
+			// then
+			Expect(err).NotTo(HaveOccurred())
+			Expect(workspace.Labels).To(HaveKeyWithValue(restworkspacesv1alpha1.LabelIsOwner, "true"))
 			validateCreatedInternalWorkspace(&workspace, workspacesv1alpha1.InternalWorkspaceVisibilityPrivate)
 		})
 	})

--- a/server/persistence/writeclient/writeclient_update_test.go
+++ b/server/persistence/writeclient/writeclient_update_test.go
@@ -177,6 +177,8 @@ var _ = Describe("WriteclientUpdate", func() {
 
 				// then
 				Expect(err).NotTo(HaveOccurred())
+
+				Expect(w.Labels).To(HaveKeyWithValue(restworkspacesv1alpha1.LabelIsOwner, "true"))
 			})
 		})
 	})


### PR DESCRIPTION
When requesting workspaces through our server, we will now label them with the label `internal.workspaces.konflux-ci.dev/is-owner`.  This label will either be set to `true` or `false` depending on whether the requesting user is an owner or not.

This label is set for all operations - get, list, create, and update.

Prerequisite for #293.