### PR TITLE
run gosec in each component separately

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -26,6 +26,9 @@ jobs:
   gosec:
     name: Gosec
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        directory: [server, operator, e2e]
 
     steps:
       - name: Checkout Git Repository
@@ -33,11 +36,13 @@ jobs:
 
       - name: Run gosec
         uses: securego/gosec@v2.20.0
+        working-directory: ${{ matrix.directory }}
         with:
           args: '-exclude=G601 -no-fail -fmt sarif -out gosec.sarif ./...'
 
       - name: Upload scan results
         uses: github/codeql-action/upload-sarif@v3
+        working-directory: ${{ matrix.directory }}
         with:
           sarif_file: gosec.sarif
 


### PR DESCRIPTION
When running gosec locally with the provided arguments, gosec reports internal panics since the top level of this repo isn't a go module.  To fix these issues, we should run gosec in each component of this repository.