### PR TITLE
rest: enforce JWT Bearer token source

### DIFF
--- a/server/config/server/proxy-config/dynamic/config.yaml
+++ b/server/config/server/proxy-config/dynamic/config.yaml
@@ -29,3 +29,6 @@ http:
           keys: []
           jwtHeaders:
             X-Subject: sub
+          jwtSources:
+          - type: bearer
+            key: Authorization


### PR DESCRIPTION
This limits the JWT source in the request to the Authorization header.

Signed-off-by: Francesco Ilario <filario@redhat.com>
